### PR TITLE
feat: bump Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: The playwright version used in the project
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.mjs'


### PR DESCRIPTION
BREAKING CHANGE: bump node version to 24